### PR TITLE
feat: use letsencrypt ca server

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -43,6 +43,7 @@ jobs:
         Ali_Secret: ${{ secrets.ALIYUN_ACCESS_KEY_SECRET }}
       run: |
         IFS=',' read -r -a domain_array <<< "${DOMAINS}"
+        ~/.acme.sh/acme.sh --set-default-ca --server letsencrypt
         for domain in "${domain_array[@]}"; do
           ~/.acme.sh/acme.sh --issue --dns dns_ali -d "*.${domain}" \
           --key-file ~/certs/${domain}/privkey.pem --fullchain-file ~/certs/${domain}/fullchain.pem

--- a/README.md
+++ b/README.md
@@ -24,3 +24,4 @@ fork该项目，并填写对应参数，再push一次代码即可（随便改点
 > 这里使用的是阿里云提供的api进行的调用
 >
 > - 设置CDN证书：https://next.api.aliyun.com/document/Cdn/2018-05-10/SetCdnDomainSSLCertificate
+


### PR DESCRIPTION
The default ca server ZeroSSL often timeouts. Use letsencrypt server instead

![image](https://github.com/user-attachments/assets/46a660d7-37c2-41b9-b7cb-d7355ed57e2a)

![image](https://github.com/user-attachments/assets/543dbcfd-57dd-4569-b712-f3bcfba3c1cf)
